### PR TITLE
Adding logic for a secret.yaml alongside the custom.yaml and Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config/secret.yaml
+secret.yaml
 .vagrant/
 .git/
 .build/

--- a/config/secret_example.yaml
+++ b/config/secret_example.yaml
@@ -1,6 +1,6 @@
 # The purpose of this file is to provide confidential variables, such as registration codes. 
 # Note that the GitHub project does not sync this file.
-# Rename this file as secret.yaml, and configure below.
+# Copy this file as secret.yaml, and configure below. The file can be placed in the root project directory or the same directory as secret_example.yaml. The root project directory secret.yaml will take precedence, if it exists.
 
 # Registration code for base SLES
 sleregcode: ""

--- a/vagrantfiles/Vagrantfile
+++ b/vagrantfiles/Vagrantfile
@@ -5,13 +5,22 @@
 
 Vagrant.configure("2") do |config|
   # The custom.yaml is the only other file you need local with your Vagrantfile of choice.
+  unless File.exist?("./custom.yaml")
+    abort("Required ./custom.yaml file does not exist. Consult vagrantfiles/custom.yaml for reference.")
+  end
   custom_vars = YAML.load_file("./custom.yaml")
   # The custom.yaml is important in determining where the root directory is for this project. It defaults to "./"
   WD = custom_vars["wheredir"]
   # This loads in global variables such as what the box names are and what box urls will be used.
   global_vars = YAML.load_file("#{WD}config/global.yaml")
   # This includes confidential information such as registration codes. The project does not sync this file.
-  secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  if File.exist?("./secret.yaml")
+    secret_vars = YAML.load_file("./secret.yaml")
+  elsif File.exist?("#{WD}config/secret.yaml")
+    secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  else
+    abort("The required ./secret.yaml or #{WD}config/secret.yaml file does not exist. Consult #{WD}config/secret_example.yaml for reference.")
+  end
 ### !! "LABNAME.yaml" must be replace with the actual lab name yaml file here. e.g. "ha.yaml" After that the variable can be pulled from the second line down from here. ###
   lab_vars = YAML.load_file("#{WD}config/lab/LABNAME.yaml")
   # Load the labname variable to be used in the rest of the template.
@@ -19,7 +28,7 @@ Vagrant.configure("2") do |config|
   # Loop over "requiredsecrets" for the lab and exit if one of the required secrets is not populated in the secret.yaml file.
   lab_vars["requiredsecrets"].each do |code|
     if (secret_vars[code.downcase].empty?)
-      abort("Required #{code.downcase} variable has not been filled out in the config/secret.yaml file.")
+      abort("Required #{code.downcase} variable has not been filled out in the secret.yaml file.")
     end
   end
   # Don't sync a files from the current directory to a "/vagrant" folder on the VMs. This is enabled by default in vagrant, but disabled by default in our project.

--- a/vagrantfiles/auth/Vagrantfile
+++ b/vagrantfiles/auth/Vagrantfile
@@ -6,15 +6,24 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure("2") do |config|
+  unless File.exist?("./custom.yaml")
+    abort("Required ./custom.yaml file does not exist. Consult vagrantfiles/custom.yaml for reference.")
+  end
   custom_vars = YAML.load_file("./custom.yaml")
   WD = custom_vars["wheredir"]
   global_vars = YAML.load_file("#{WD}config/global.yaml")
-  secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  if File.exist?("./secret.yaml")
+    secret_vars = YAML.load_file("./secret.yaml")
+  elsif File.exist?("#{WD}config/secret.yaml")
+    secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  else
+    abort("The required ./secret.yaml or #{WD}config/secret.yaml file does not exist. Consult #{WD}config/secret_example.yaml for reference.")
+  end
   lab_vars = YAML.load_file("#{WD}config/lab/auth.yaml")
   LABNAME = lab_vars["labname"]
   lab_vars["requiredsecrets"].each do |code|
     if (secret_vars[code.downcase].empty?)
-      abort("Required #{code.downcase} variable has not been filled out in the config/secret.yaml file.")
+      abort("Required #{code.downcase} variable has not been filled out in the secret.yaml file.")
     end
   end
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/vagrantfiles/basic/Vagrantfile
+++ b/vagrantfiles/basic/Vagrantfile
@@ -2,15 +2,24 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
+  unless File.exist?("./custom.yaml")
+    abort("Required ./custom.yaml file does not exist. Consult vagrantfiles/custom.yaml for reference.")
+  end
   custom_vars = YAML.load_file("./custom.yaml")
   WD = custom_vars["wheredir"]
   global_vars = YAML.load_file("#{WD}config/global.yaml")
-  secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  if File.exist?("./secret.yaml")
+    secret_vars = YAML.load_file("./secret.yaml")
+  elsif File.exist?("#{WD}config/secret.yaml")
+    secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  else
+    abort("The required ./secret.yaml or #{WD}config/secret.yaml file does not exist. Consult #{WD}config/secret_example.yaml for reference.")
+  end
   lab_vars = YAML.load_file("#{WD}config/lab/basic.yaml")
   LABNAME = lab_vars["labname"]
   lab_vars["requiredsecrets"].each do |code|
     if (secret_vars[code.downcase].empty?)
-      abort("Required #{code.downcase} variable has not been filled out in the config/secret.yaml file.")
+      abort("Required #{code.downcase} variable has not been filled out in the secret.yaml file.")
     end
   end
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/vagrantfiles/ha12/Vagrantfile
+++ b/vagrantfiles/ha12/Vagrantfile
@@ -7,15 +7,24 @@
 # you're doing.
 
 Vagrant.configure("2") do |config|
+  unless File.exist?("./custom.yaml")
+    abort("Required ./custom.yaml file does not exist. Consult vagrantfiles/custom.yaml for reference.")
+  end
   custom_vars = YAML.load_file("./custom.yaml")
   WD = custom_vars["wheredir"]
   global_vars = YAML.load_file("#{WD}config/global.yaml")
-  secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  if File.exist?("./secret.yaml")
+    secret_vars = YAML.load_file("./secret.yaml")
+  elsif File.exist?("#{WD}config/secret.yaml")
+    secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  else
+    abort("The required ./secret.yaml or #{WD}config/secret.yaml file does not exist. Consult #{WD}config/secret_example.yaml for reference.")
+  end
   lab_vars = YAML.load_file("#{WD}config/lab/ha12.yaml")
   LABNAME = lab_vars["labname"]
   lab_vars["requiredsecrets"].each do |code|
     if (secret_vars[code.downcase].empty?)
-      abort("Required #{code.downcase} variable has not been filled out in the config/secret.yaml file.")
+      abort("Required #{code.downcase} variable has not been filled out in the secret.yaml file.")
     end
   end
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/vagrantfiles/ha15/Vagrantfile
+++ b/vagrantfiles/ha15/Vagrantfile
@@ -7,15 +7,24 @@
 # you're doing.
 
 Vagrant.configure("2") do |config|
+  unless File.exist?("./custom.yaml")
+    abort("Required ./custom.yaml file does not exist. Consult vagrantfiles/custom.yaml for reference.")
+  end
   custom_vars = YAML.load_file("./custom.yaml")
   WD = custom_vars["wheredir"]
   global_vars = YAML.load_file("#{WD}config/global.yaml")
-  secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  if File.exist?("./secret.yaml")
+    secret_vars = YAML.load_file("./secret.yaml")
+  elsif File.exist?("#{WD}config/secret.yaml")
+    secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  else
+    abort("The required ./secret.yaml or #{WD}config/secret.yaml file does not exist. Consult #{WD}config/secret_example.yaml for reference.")
+  end
   lab_vars = YAML.load_file("#{WD}config/lab/ha15.yaml")
   LABNAME = lab_vars["labname"]
   lab_vars["requiredsecrets"].each do |code|
     if (secret_vars[code.downcase].empty?)
-      abort("Required #{code.downcase} variable has not been filled out in the config/secret.yaml file.")
+      abort("Required #{code.downcase} variable has not been filled out in the secret.yaml file.")
     end
   end
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/vagrantfiles/hana15/Vagrantfile
+++ b/vagrantfiles/hana15/Vagrantfile
@@ -2,15 +2,24 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
+  unless File.exist?("./custom.yaml")
+    abort("Required ./custom.yaml file does not exist. Consult vagrantfiles/custom.yaml for reference.")
+  end
   custom_vars = YAML.load_file("./custom.yaml")
   WD = custom_vars["wheredir"]
   global_vars = YAML.load_file("#{WD}config/global.yaml")
-  secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  if File.exist?("./secret.yaml")
+    secret_vars = YAML.load_file("./secret.yaml")
+  elsif File.exist?("#{WD}config/secret.yaml")
+    secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  else
+    abort("The required ./secret.yaml or #{WD}config/secret.yaml file does not exist. Consult #{WD}config/secret_example.yaml for reference.")
+  end
   lab_vars = YAML.load_file("#{WD}config/lab/hana15.yaml")
   LABNAME = lab_vars["labname"]
   lab_vars["requiredsecrets"].each do |code|
     if (secret_vars[code.downcase].empty?)
-      abort("Required #{code.downcase} variable has not been filled out in the config/secret.yaml file.")
+      abort("Required #{code.downcase} variable has not been filled out in the secret.yaml file.")
     end
   end
   if Dir.entries("#{WD}provisioners/lab/#{LABNAME}/hanaiso/").size <= 3

--- a/vagrantfiles/s4hana/Vagrantfile
+++ b/vagrantfiles/s4hana/Vagrantfile
@@ -2,15 +2,24 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
+  unless File.exist?("./custom.yaml")
+    abort("Required ./custom.yaml file does not exist. Consult vagrantfiles/custom.yaml for reference.")
+  end
   custom_vars = YAML.load_file("./custom.yaml")
   WD = custom_vars["wheredir"]
   global_vars = YAML.load_file("#{WD}config/global.yaml")
-  secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  if File.exist?("./secret.yaml")
+    secret_vars = YAML.load_file("./secret.yaml")
+  elsif File.exist?("#{WD}config/secret.yaml")
+    secret_vars = YAML.load_file("#{WD}config/secret.yaml")
+  else
+    abort("The required ./secret.yaml or #{WD}config/secret.yaml file does not exist. Consult #{WD}config/secret_example.yaml for reference.")
+  end
   lab_vars = YAML.load_file("#{WD}config/lab/s4hana.yaml")
   LABNAME = lab_vars["labname"]
   lab_vars["requiredsecrets"].each do |code|
     if (secret_vars[code.downcase].empty?)
-      abort("Required #{code.downcase} variable has not been filled out in the config/secret.yaml file.")
+      abort("Required #{code.downcase} variable has not been filled out in the secret.yaml file.")
     end
   end
   if Dir.entries("#{WD}provisioners/lab/#{LABNAME}/sapcd/").size <= 3


### PR DESCRIPTION
The idea had always been to allow multiple users to use the same project on the same server. I hadn't realized it was still requiring all users to use the same registration codes. This will allow each user to have their own secret.yaml file.