### PR TITLE
HANA15 deploys no longer consistently work with 10GB RAM. They need a…

### DIFF
--- a/vagrantfiles/hana15/custom.yaml
+++ b/vagrantfiles/hana15/custom.yaml
@@ -4,7 +4,7 @@ deployment: "fulldeploy"
 extra: false
 libvirt:
   cpus: 4
-  memory: 10240
+  memory: 16384
   machine_virtual_size: 42
 network:
   bridgename: "br0"


### PR DESCRIPTION
…t least 16GB of RAM each.